### PR TITLE
Fix segmented control compatibility on GNUstep

### DIFF
--- a/GFinder/FileViewer/GWViewer.h
+++ b/GFinder/FileViewer/GWViewer.h
@@ -46,7 +46,7 @@ typedef enum
 @class NSTextField;
 @class NSToolbar;
 @class NSToolbarItem;
-@class NSButton;
+@class NSSegmentedControl;
 @class NSPopUpButton;
 @class GFinder;
 
@@ -65,13 +65,9 @@ typedef enum
   NSToolbar *toolbar;
   NSToolbarItem *backItem;
   NSToolbarItem *forwardItem;
-  NSToolbarItem *iconItem;
-  NSToolbarItem *listItem;
-  NSToolbarItem *browserItem;
+  NSToolbarItem *viewTypeItem;
   NSToolbarItem *sortItem;
-  NSButton *iconButton;
-  NSButton *listButton;
-  NSButton *browserButton;
+  NSSegmentedControl *viewTypeControl;
   NSPopUpButton *sortButton;
 
   NSDictionary *viewerPrefs;


### PR DESCRIPTION
## Summary
- guard NSSegmentedControl configuration against unavailable GNUstep selectors
- fall back to setSelectedSegment: when setSelected:forSegment: is not implemented
- avoid selecting an invalid segment index on GNUstep implementations that cannot deselect segments
- map segmented control selections without tagForSegment: so legacy GNUstep builds continue to switch views

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68c86147d41083309ae06c30186a1286